### PR TITLE
Fix notify-send based notifications

### DIFF
--- a/tasks/lib/platforms/notify-send.js
+++ b/tasks/lib/platforms/notify-send.js
@@ -23,7 +23,7 @@ module.exports = isSupported() && function(options, cb) {
     APP,
     escapeForCommandLine(options.title),
     escapeForCommandLine(options.message)
-  ];
+  ].join(' ');
 
   return ChildProcess.exec(cmd, cb);
 };


### PR DESCRIPTION
The notify-send platform specific command was not sending the proper command to ChildProcess.exec; needs spaces not commas.
