### PR TITLE
Correct for the stack trace not existing

### DIFF
--- a/tasks/lib/hooks/notify-fail.js
+++ b/tasks/lib/hooks/notify-fail.js
@@ -13,13 +13,16 @@ module.exports = function(grunt, options) {
   var notify = require('../notify');
 
   function exception(e) {
-    var stackDump = StackParser.parse(e.stack);
-    var stack = stackDump[0];
-    var message;
+    var stackDump, stack, message;
 
-    // Find the first stack that isn't a node module or an internal Node function
-    while (stack && (stack.file.match('/node_modules') || !stack.file.match('/'))) {
-      stack = stackDump.shift();
+    if (typeof e.stack !== 'string'){
+      stackDump = StackParser.parse(e.stack);
+      stack = stackDump[0];
+
+      // Find the first stack that isn't a node module or an internal Node function
+      while (stack && (stack.file.match('/node_modules') || !stack.file.match('/'))) {
+        stack = stackDump.shift();
+      }
     }
 
     if (stack) {


### PR DESCRIPTION
Fixes this error:

``` bash
node_modules/grunt-notify/node_modules/stack-parser/index.js:49
  lines.forEach(function(line) {
        ^
TypeError: Cannot call method 'forEach' of null
    at Object.parse (node_modules/grunt-notify/node_modules/stack-parser/index.js:49:8)
    at notifyException (node_modules/grunt-notify/tasks/notify.js:81:31)
    at Object.notifyHook (node_modules/grunt-notify/tasks/notify.js:125:16)
    at Object.hooked [as fatal] (node_modules/grunt/node_modules/hooker/lib/hooker.js:108:32)
    at process.uncaughtHandler (node_modules/grunt/lib/grunt.js:123:10)
    at process.EventEmitter.emit (events.js:117:20)
    at process._fatalException (node.js:272:26)
DEBUG: Program grunt code exited with code 7
```
