### PR TITLE
Support for Snarl

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # grunt-notify
 
-> Automatic desktop notifications for Grunt errors and warnings using Growl for OS X or Windows, Mountain Lion Notification Center, and Notify-Send.
+> Automatic desktop notifications for Grunt errors and warnings using Growl for OS X or Windows, Snarl, Mountain Lion Notification Center, and Notify-Send.
 
 [![Growl: JSHint](screenshots/growl-jshint.png)](https://github.com/dylang/grunt-notify)
 [![Notification Center: JSHint](screenshots/notification-center-jshint.png)](https://github.com/dylang/grunt-notify)
@@ -22,6 +22,8 @@ Once that's done, add this line to your project's `Gruntfile.js`:
 // Automatic notifications when tasks fail.
 grunt.loadNpmTasks('grunt-notify');
 ```
+
+Make sure the application directory of Growl/Snarl is on your system `path`. For Snarl this has to be the `tools` folder, where `heysnarl.exe` is located.
 
 **That's all you need for automatic notifications.**
 

--- a/tasks/lib/notify.js
+++ b/tasks/lib/notify.js
@@ -12,6 +12,7 @@
 var notify = require('./platforms/growl-notify') ||
   require('./platforms/notification-center') ||
   require('./platforms/notify-send') ||
+  require('./platforms/snarl') ||
   function(options, cb) {
     // no notification system
     cb && cb();

--- a/tasks/lib/platforms/snarl.js
+++ b/tasks/lib/platforms/snarl.js
@@ -1,0 +1,68 @@
+/*
+ * grunt-notify
+ * https://github.com/dylang/grunt-notify
+ *
+ * Copyright (c) 2013 Dylan Greene
+ * Licensed under the MIT license.
+ */
+'use strict';
+
+var path = require('path');
+var os = require('os');
+var findApp = require('../util/findApp');
+var spawn = require('../util/spawn');
+var path = require('path');
+
+var cmd = 'node';
+var IS_WINDOWS = os.type() === 'Windows_NT';
+var DEFAULT_IMAGE = path.resolve(__dirname + '../../../../images/grunt-logo.png');
+
+function isSupported() {
+  return  IS_WINDOWS && findApp(cmd) && findApp('heysnarl');
+}
+
+module.exports = isSupported() && function (options, cb) {
+  var cmdPath = path.join(__dirname, "snarl_cmd.js");
+
+  // stripping all special characters to have a valid app signiture
+  var appSig = 'grunt-notify-' + options.title.replace(/[^a-zA-Z0-9]/g, "");
+  
+  var args = {
+    register: 'register?app-sig=app/' + appSig +
+              '&title=' + options.title + ' (grunt-notify)' +
+              '&keep-alive=1',
+
+    notification: 'notify?app-sig=app/' + appSig +
+           '&title=' + options.title + ' (grunt-notify)' +
+           '&text=' + options.message
+  };
+
+  // TODO: find a way to pass options, so that they can be used here
+  if(!options.useSnarlIcon) {
+    args.notification += '&icon=' + (options.image || DEFAULT_IMAGE);
+  }
+
+  if(options.sound) {
+    args.notification += '&sound=' + options.sound;
+  }
+
+  if(options.timeout) {
+    args.notification += '&timeout=' + options.timeout;
+  }
+
+  if(options.priority) {
+    args.notification += '&priority=' + options.priority;
+  }
+
+  if(options.sensitivity) {
+    args.notification += '&sensitivity=' + options.sensitivity;
+  }
+
+  // additional custom arguments
+  if(options.customSnarlArgs) {
+     args.notification += options.customSnarlArgs;
+  }
+  
+  spawn(cmd, [cmdPath, JSON.stringify(args)], cb);
+};
+

--- a/tasks/lib/platforms/snarl_cmd.js
+++ b/tasks/lib/platforms/snarl_cmd.js
@@ -1,0 +1,9 @@
+var spawn = require('../util/spawn');
+
+var cmd = 'heysnarl';
+
+var args = JSON.parse(process.argv[2]);
+
+spawn(cmd, [args.register], function () {
+  spawn(cmd, [args.notification]);
+});


### PR DESCRIPTION
Adding support for Snarl.

Because we always need to execute 2 commands (one for registering, one for showing the notification) I had to combine those into a single node-script that is executed. Otherwise it wouldn't work as Grunt is exiting the process and does not wait for the callback of the spawn for the first command.

I also added options that can be passed to snarl, like `timeout`. unfortunately i wasn't quite sure how to pass them through from the gruntfile to the notifier, so i left that up to you... meaning, there are no options passed yet, except for `image`, `title` and `message`.
