### PR TITLE
Fix semver parsing on Linux

### DIFF
--- a/tasks/lib/platforms/notification-center.js
+++ b/tasks/lib/platforms/notification-center.js
@@ -28,7 +28,6 @@ function notificationCenterSupported(options) {
     version: os.release(),
     IS_MAC: IS_MAC,
     MOUNTAIN_LION: MOUNTAIN_LION,
-    semver: semver.satisfies(os.release(), '>=12.0.0'),
     notification_center: MOUNTAIN_LION ? 'Will use Notification Center' : 'Not available for your OS.'
   });
 


### PR DESCRIPTION
We started experiencing failures with `grunt-notify` running on Linux boxes recently:

```
/home/devsuprt/fc-test/node_modules/grunt-notify/node_modules/semver/semver.js:271
    throw new TypeError('Invalid Version: ' + version);
          ^
TypeError: Invalid Version: 2.6.32-358.6.1.el6.x86_64
    at new SemVer (/home/devsuprt/fc-test/node_modules/grunt-notify/node_modules/semver/semver.js:271:11)
    at compare (/home/devsuprt/fc-test/node_modules/grunt-notify/node_modules/semver/semver.js:424:10)
    at gte (/home/devsuprt/fc-test/node_modules/grunt-notify/node_modules/semver/semver.js:473:10)
    at cmp (/home/devsuprt/fc-test/node_modules/grunt-notify/node_modules/semver/semver.js:490:22)
    at Comparator.test (/home/devsuprt/fc-test/node_modules/grunt-notify/node_modules/semver/semver.js:560:10)
    at testSet (/home/devsuprt/fc-test/node_modules/grunt-notify/node_modules/semver/semver.js:885:17)
    at Range.test (/home/devsuprt/fc-test/node_modules/grunt-notify/node_modules/semver/semver.js:877:9)
    at Function.satisfies (/home/devsuprt/fc-test/node_modules/grunt-notify/node_modules/semver/semver.js:898:16)
    at Object.notificationCenterSupported [as supported] (/home/devsuprt/fc-test/node_modules/grunt-notify/tasks/lib/platforms/notification-center.js:24:30)
    at choosePlatform (/home/devsuprt/fc-test/node_modules/grunt-notify/tasks/lib/notify.js:34:27)
    at postNotification (/home/devsuprt/fc-test/node_modules/grunt-notify/tasks/lib/notify.js:64:22)
    at Object.notifyHook (/home/devsuprt/fc-test/node_modules/grunt-notify/tasks/lib/hooks/notify-fail.js:72:12)
    at Object.hooked [as fatal] (/home/devsuprt/fc-test/node_modules/grunt/node_modules/hooker/lib/hooker.js:108:32)
    at process.grunt.tasks.uncaughtHandler (/home/devsuprt/fc-test/node_modules/grunt/lib/grunt.js:123:10)
    at process.EventEmitter.emit (events.js:126:20)
```

From what I can gather from this log, the problem is that the linux kernel version is being passed to the semver module, but it doesn't parse correctly as a semver.

This pull request has a tentative fix to [the recent change](https://github.com/dylang/grunt-notify/commit/4db760bfbedba04662b53a5de9db35210180ffab) made to the notification-center.js file, so as to only check for Mountain Lion (using the offending semver parsing code) iff on Mac.

I've not been able to reproduce the issue above 100% reliably, so it would be nice if someone could review my proposed fix and let me know if it's sane.
