### PR TITLE
Fix for Snarl and Growl on Windows

### DIFF
--- a/tasks/lib/platforms/growl-notify.js
+++ b/tasks/lib/platforms/growl-notify.js
@@ -69,7 +69,7 @@ function createImageArg(image) {
 
   if (IS_WINDOWS) {
     return [
-      '/i:' + image
+      '/i:"' + image.replace(new RegExp(/\\/g),'/') + '"'
     ];
   }
 

--- a/tasks/lib/platforms/hey-snarl.js
+++ b/tasks/lib/platforms/hey-snarl.js
@@ -55,10 +55,10 @@ function escape(str) {
 function notify(options, cb) {
 
   var args = [
-    'notify?' +
+    '"notify?' +
     'title=' + escape(options.title) + '&' +
     'text=' + escape(options.message) + '&' +
-    'icon=' + (options.image || DEFAULT_IMAGE)
+    'icon=' + (options.image || DEFAULT_IMAGE.replace(new RegExp(/\\/g),'/'))  + '"'
     ];
 
   options.debug({


### PR DESCRIPTION
Turn backslashes in forward slashes on Windows, so the `growlnotify` and the `heysnarl`  commands will recognize the image path.
