### PR TITLE
Add fail notification hooks before tasks run

### DIFF
--- a/tasks/lib/hooks/notify-fail.js
+++ b/tasks/lib/hooks/notify-fail.js
@@ -82,14 +82,19 @@ module.exports = function(grunt, options) {
     });
   }
 
-  // run on warning
-  grunt.util.hooker.hook(grunt, 'warn', notifyHook);
-  grunt.util.hooker.hook(grunt.fail, 'warn', notifyHook);
-  // run on error
-  grunt.util.hooker.hook(grunt.fail, 'error', notifyHook);
-  grunt.util.hooker.hook(grunt.log, 'fail', notifyHook);
-  // run on fatal
-  grunt.util.hooker.hook(grunt.fail, 'fatal', notifyHook);
+  // attach the notification hooks every time before an event is
+  // fired, just in case any of the fail or warning methods where
+  // overidden
+  grunt.event.on('*', function () {
+    // run on warning
+    grunt.util.hooker.hook(grunt, 'warn', notifyHook);
+    grunt.util.hooker.hook(grunt.fail, 'warn', notifyHook);
+    // run on error
+    grunt.util.hooker.hook(grunt.fail, 'error', notifyHook);
+    grunt.util.hooker.hook(grunt.log, 'fail', notifyHook);
+    // run on fatal
+    grunt.util.hooker.hook(grunt.fail, 'fatal', notifyHook);
+  });
 
   function setOptions(opts) {
     options = opts;


### PR DESCRIPTION
This will resolve #39 where running a `grunt-contrib-watch` task with `spawn:false` would not produce notifications on failure.

I'm not entirely sure if this is the best solution, but it's what I could come up with in a limited amount of time.

I see that there are sample watch tasks in the Grunt configuration file, but I didn't see that they where used in any tests. Perhaps someone can help set these up with some tests. Will see if I can get to it myself when I have time.
