### PR TITLE
Show a notification on grunt.log#error

### DIFF
--- a/tasks/lib/hooks/notify-fail.js
+++ b/tasks/lib/hooks/notify-fail.js
@@ -88,6 +88,7 @@ module.exports = function(grunt, options) {
   // run on error
   grunt.util.hooker.hook(grunt.fail, 'error', notifyHook);
   grunt.util.hooker.hook(grunt.log, 'fail', notifyHook);
+  grunt.util.hooker.hook(grunt.log, 'error', notifyHook);
   // run on fatal
   grunt.util.hooker.hook(grunt.fail, 'fatal', notifyHook);
 


### PR DESCRIPTION
just a quick patch to also show a notification on log.error(), which has proven useful for a couple plugins.  cheers!
