### PR TITLE
Avoid multiple notifications with notify-send

### DIFF
--- a/lib/platforms/notify-send.js
+++ b/lib/platforms/notify-send.js
@@ -30,6 +30,7 @@ function supported(options) {
 function notify(options, cb) {
 
   var args = [
+    '--hint=int:transient:1',
     '--icon=' + DEFAULT_IMAGE,
     options.title,
     options.message


### PR DESCRIPTION
This fix will tell notify-send to use transient notifications thus avoiding
a flood of alerts that need to be dismissed (seen at least with gnome-shell).
