### PR TITLE
make sure a message is a string

### DIFF
--- a/lib/hooks/notify-fail.js
+++ b/lib/hooks/notify-fail.js
@@ -89,7 +89,7 @@ module.exports = function(grunt, options) {
     } else if (e.message && e.stack) {
       message = exception(e);
     } else {
-      message = e;
+      message = e + '';
     }
 
     if (message_count > 0 && message === 'Aborted due to warnings.') {


### PR DESCRIPTION
Another error happens when an error instance has no message.

"Object Error has no method 'replace'" 
