### PR TITLE
Register custom message types on growl for windows

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -21,6 +21,13 @@ module.exports = function(grunt) {
           message: 'This is a "Notify Message" test!'
         }
       },
+      success: {
+        options: {
+          type: 'success',
+          title: 'Success',
+          message: 'This is a success message!'
+        }
+      },
       just_message: {
         options: {
           message: 'Just Message'

--- a/lib/notify-lib.js
+++ b/lib/notify-lib.js
@@ -27,6 +27,7 @@ function choosePlatform() {
   var growl_notify = require('./platforms/growl-notify');
 
   if (growl_notify.supported(options)) {
+    growl_notify.register()
     return growl_notify;
   }
 

--- a/lib/platforms/growl-notify.js
+++ b/lib/platforms/growl-notify.js
@@ -38,6 +38,14 @@ function supported(options) {
   return !!app;
 }
 
+function register() {
+  if(!IS_WINDOWS){
+    return;
+  }
+
+  spawn(cmd, ['/a:grunt-notify', '/r:failure,success', 'registered']);
+}
+
 function createImageArg(image) {
 
   var imageType = '';
@@ -92,14 +100,17 @@ function createMessageArg(message) {
   ];
 }
 
+function createApplicationArgs() {
+  return IS_WINDOWS ? [ '/a:grunt-notify' ] : [];
+}
+
 function createTypeArg(type) {
-  return [
-    windowsOnly('/n:' + type)
-  ];
+  return IS_WINDOWS ? [ '/n:' + type ] : [];
 }
 
 function notify(options, cb) {
   var args = []
+      .concat(createApplicationArgs())
       .concat(createImageArg(options.image))
       .concat(createTypeArg(options.type))
       .concat(createMessageArg(options.message))
@@ -123,5 +134,6 @@ function notify(options, cb) {
 module.exports = {
   name: NOTIFY_TYPE,
   supported: supported,
-  notify: notify
+  notify: notify,
+  register:register
 };

--- a/lib/platforms/growl-notify.js
+++ b/lib/platforms/growl-notify.js
@@ -92,10 +92,16 @@ function createMessageArg(message) {
   ];
 }
 
-function notify(options, cb) {
+function createTypeArg(type) {
+  return [
+    windowsOnly('/n:' + type)
+  ];
+}
 
+function notify(options, cb) {
   var args = []
       .concat(createImageArg(options.image))
+      .concat(createTypeArg(options.type))
       .concat(createMessageArg(options.message))
       .concat(createTitleArg(options.title));
 

--- a/tasks/notify.js
+++ b/tasks/notify.js
@@ -12,6 +12,7 @@ module.exports = function gruntTask(grunt) {
   var guessProjectName = require('../lib/util/guessProjectName');
 
   var defaults = {
+    type: 'error',
     title:    guessProjectName(),
     message:  '' //required
   };

--- a/tasks/notify.js
+++ b/tasks/notify.js
@@ -12,7 +12,7 @@ module.exports = function gruntTask(grunt) {
   var guessProjectName = require('../lib/util/guessProjectName');
 
   var defaults = {
-    type: 'error',
+    type: 'failure',
     title:    guessProjectName(),
     message:  '' //required
   };

--- a/tasks/notify_hooks.js
+++ b/tasks/notify_hooks.js
@@ -14,6 +14,7 @@ module.exports = function gruntTask(grunt) {
   // All of these settings are customizable via notify_hooks
   var defaults = {
     enabled: true,
+    type:'error',
     max_jshint_notifications: 5,
     title: guessProjectName()
   };

--- a/tasks/notify_hooks.js
+++ b/tasks/notify_hooks.js
@@ -14,7 +14,7 @@ module.exports = function gruntTask(grunt) {
   // All of these settings are customizable via notify_hooks
   var defaults = {
     enabled: true,
-    type:'error',
+    type:'failure',
     max_jshint_notifications: 5,
     title: guessProjectName()
   };


### PR DESCRIPTION
Register custom message types on growl for windows
-  Add support for success and failure typed messages
   on windows.

Note: This only works with growl for windows, and as such should
be considered and experimental feature.
