### PR TITLE
Fix duration option

### DIFF
--- a/lib/hooks/notify-fail.js
+++ b/lib/hooks/notify-fail.js
@@ -103,7 +103,8 @@ module.exports = function(grunt, options) {
 
     return notify({
       title:    options.title + (grunt.task.current.nameArgs ? ' ' + grunt.task.current.nameArgs : ''),
-      message:  message
+      message:  message,
+      duration: options.duration
     });
   }
 


### PR DESCRIPTION
Duration option used with notify-send is ignored because it is not forwared from notify-fail to notify-send. This commit fixes the problem.
