### PR TITLE
Fix image/icon display on Growl for Windows and quote path if necessary

### DIFF
--- a/lib/platforms/growl-notify.js
+++ b/lib/platforms/growl-notify.js
@@ -38,6 +38,12 @@ function supported(options) {
   return !!app;
 }
 
+function quoteIfNecessary(value) {
+  /* Quoting is necessary (on Windows) when the value contains a space and has not already been quoted. */
+  var isNecessary = / /.test(value) && value.substring(0, 1) !== '"'
+  return isNecessary ? '"' + value + '"' : value
+}
+
 function createImageArg(image) {
 
   var imageType = '';
@@ -69,7 +75,7 @@ function createImageArg(image) {
 
   if (IS_WINDOWS) {
     return [
-      '/i:' + image
+      '/i:' + quoteIfNecessary(image.replace(/\\/g, '/'))
     ];
   }
 

--- a/test/notify.test.js
+++ b/test/notify.test.js
@@ -47,6 +47,18 @@ describe('grunt-notify', function () {
       console.log(cmd, args.join(' '));
       cb();
     }
+    
+    function imageArgumentAssertions(cmd, args, cb) {
+      fakeSpawn(cmd, args, function () {
+        var imageArgument = args[0].substr(3), // argument after /i:
+            hasSpaces = / /.test(imageArgument);
+        expect(imageArgument).to.match(/\//g);
+        if (hasSpaces) {
+          expect(imageArgument).to.match(/^\".+\"$/);
+        }
+        cb();
+      });
+    }
 
     var options = {
       debug: debug
@@ -63,6 +75,14 @@ describe('grunt-notify', function () {
       }
 
       growl.notify({ title: 'title', message: 'message', debug: debug }, done);
+    });
+    
+    it('growl for windows image path set with *nix path separator', function (done) {
+      if (require('os').type() !== 'Windows_NT') return;
+      
+      var growl = proxyquire('../lib/platforms/growl-notify', { '../util/spawn': imageArgumentAssertions });
+
+      growl.notify({ title: 'title', message: 'message', debug: debug}, done);
     });
 
     it('notification center', function (done) {


### PR DESCRIPTION
Growl for Windows was not displaying the grunt-logo.png icon and needs the *nix path separator instead of the Windows path separator to work.  Additionally, if the path contained spaces it would fail with the following error since it interprets everything past the initial space (and up 'til another option, like /t) as the message:

Bad arguments : An item with the same key has already been added.

This commit fixes both issues and adds a test to ensure that, on Windows only, the spawned process is called with an appropriate image argument (*nix path separators and quoted, if the path contains spaces).

This fixes [#36](https://github.com/dylang/grunt-notify/issues/36)
