### PR TITLE
option to enqueue failure messages

### DIFF
--- a/lib/hooks/notify-fail.js
+++ b/lib/hooks/notify-fail.js
@@ -10,11 +10,33 @@
 module.exports = function(grunt, options) {
 
   var message_count = 0;
+  var message_queue = [];
+  var message_timeout;
+
   var StackParser = require('stack-parser');
   var notify = require('../notify-lib');
   var removeColor = require('../util/removeColor');
 
   var cwd = process.cwd();
+
+  function flushQueue() {
+    if (!options.queue) return;
+    if (message_queue.length === 0) return;
+    if (message_timeout) message_timeout = null;
+
+    var title = message_queue[0].title;
+    var messages = [];
+    for (var i = 0; i < message_queue.length; i++) {
+      messages.push(message_queue[i].message);
+    }
+    messages = grunt.util._.uniq(messages);
+
+    message_queue = [];
+    notify({
+      title: title,
+      message: messages.join('\n')
+    });
+  };
 
   function watchForContribWatchWarnings(e) {
 
@@ -67,10 +89,9 @@ module.exports = function(grunt, options) {
    * @returns {*}
    */
   function notifyHook(e) {
-
     message_count++;
 
-    var message;
+    var message, enqueue;
 
     if (!options.enabled) {
       return;
@@ -101,7 +122,14 @@ module.exports = function(grunt, options) {
     // TODO - make a global replace
     message = message.replace(cwd, '').replace('\x07', '');
 
-    return notify({
+    enqueue = !options.queue ? notify : function (msg) {
+      message_queue.push(msg);
+
+      if (message_timeout) return;
+      message_timeout = setImmediate(flushQueue);
+    };
+
+    return enqueue({
       title:    options.title + (grunt.task.current.nameArgs ? ' ' + grunt.task.current.nameArgs : ''),
       message:  message
     });
@@ -121,6 +149,10 @@ module.exports = function(grunt, options) {
   // we need to watch all writeln's too
   // https://github.com/gruntjs/grunt-contrib-watch/issues/232
   grunt.util.hooker.hook(grunt.log, 'writeln', watchForContribWatchWarnings);
+
+  // flush notifications on complete
+  grunt.util.hooker.hook(grunt.util, 'exit', flushQueue);
+  grunt.util.hooker.hook(grunt.fail, 'report', flushQueue);
 
   function setOptions(opts) {
     options = opts;


### PR DESCRIPTION
I've noticed that many plugins make several calls to `grunt.log.fail` in a row.  This option allows those calls to be queued up into a single notification.

I'm not convinced this is necessarily the best way to do this, particularly since I don't try to group by task or anything like that.  Feel free to complain about that or anything else.
