### PR TITLE
Supporting successful grunt executions notification

### DIFF
--- a/lib/hooks/notify-fail.js
+++ b/lib/hooks/notify-fail.js
@@ -16,6 +16,14 @@ module.exports = function(grunt, options) {
 
   var cwd = process.cwd();
 
+  function toggleSuccessNotify() {
+	if (!!options.success) {
+	  grunt.util.hooker.hook(grunt.log, 'success', notifyHook);
+	} else {
+	  grunt.util.hooker.unhook(grunt.log, 'success');
+	}
+  }
+
   function watchForContribWatchWarnings(e) {
 
     if (!e || typeof e !== 'string') {
@@ -103,7 +111,8 @@ module.exports = function(grunt, options) {
 
     return notify({
       title:    options.title + (grunt.task.current.nameArgs ? ' ' + grunt.task.current.nameArgs : ''),
-      message:  message
+      message:  message,
+	  duration: options.duration
     });
   }
 
@@ -116,6 +125,8 @@ module.exports = function(grunt, options) {
   grunt.util.hooker.hook(grunt.log, 'error', notifyHook);
   // run on fatal
   grunt.util.hooker.hook(grunt.fail, 'fatal', notifyHook);
+  // run on success
+  toggleSuccessNotify();
 
   // grunt-contrib-watch replaces some of these functions so
   // we need to watch all writeln's too
@@ -124,6 +135,7 @@ module.exports = function(grunt, options) {
 
   function setOptions(opts) {
     options = opts;
+	toggleSuccessNotify();
   }
 
   return {

--- a/tasks/notify_hooks.js
+++ b/tasks/notify_hooks.js
@@ -15,7 +15,9 @@ module.exports = function gruntTask(grunt) {
   var defaults = {
     enabled: true,
     max_jshint_notifications: 5,
-    title: guessProjectName()
+    title: guessProjectName(),
+	success: false,
+	duration: null
   };
 
   var notifyFail = require('../lib/hooks/notify-fail')(grunt, defaults);

--- a/templates/readme/notification-systems.md
+++ b/templates/readme/notification-systems.md
@@ -52,6 +52,10 @@ I don't use Linux frequently so I don't know if this utility is available for ot
 
 `notify-send` has an addition `duration` option which takes a number seconds. The default is 3 seconds.
 
+Duration doesn't work natively on some versions of Ubuntu.
+
+Here is a fix: http://askubuntu.com/questions/128474/how-to-customize-on-screen-notifications
+
 ### Chrome
 
 *Not supported yet.*

--- a/templates/readme/options-notify-hooks.md
+++ b/templates/readme/options-notify-hooks.md
@@ -9,7 +9,9 @@ grunt.initConfig({
     options: {
       enabled: true,
       max_jshint_notifications: 5, // maximum number of notifications from jshint output
-      title: "Project Name" // defaults to the name in package.json, or will use project directory's name
+      title: "Project Name", // defaults to the name in package.json, or will use project directory's name
+      success: false, // whether successful grunt executions should be notified automatically
+      duration: 3 // the duration of notification in seconds, for notify-send only
     }
   }
 });


### PR DESCRIPTION
Hi!

Needed an option to automatically support success notifications, e.g. when grunt target is completed without issues. Specifically wanted this for watch, so console can be in the background. My grunt setup is a bit contrived since it is a part of maven multimodule project and some tasks are generated dynamically, hence the need to notify of success by default.

Added the option to turn on this behavior, off by default. `lib/hooks/notify-fail.js` might be a bit wrong place for this (based on file name), but it felt most natural to place it there.

Also, added an option to set the duration option for notify-send.

Kudos for the plugin :-)
