### PR TITLE
Suppress notifications before specified process uptime.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ grunt.initConfig({
       max_jshint_notifications: 5, // maximum number of notifications from jshint output
       title: "Project Name", // defaults to the name in package.json, or will use project directory's name
       success: false, // whether successful grunt executions should be notified automatically
-      duration: 3 // the duration of notification in seconds, for `notify-send only
+      duration: 3, // the duration of notification in seconds, for `notify-send only
+      threshold: 0 // number of seconds for process uptime to reach before messages should be sent 
     }
   }
 });

--- a/lib/hooks/notify-fail.js
+++ b/lib/hooks/notify-fail.js
@@ -80,7 +80,7 @@ module.exports = function(grunt, options) {
 
     var message;
 
-    if (!options.enabled) {
+    if (!options.enabled || process.uptime() < options.threshold) {
       return;
     }
 

--- a/lib/hooks/notify-jshint.js
+++ b/lib/hooks/notify-jshint.js
@@ -42,7 +42,7 @@ module.exports = function(grunt, options) {
   }
 
   function grabErrors(message) {
-    if (!options.enabled) {
+    if (!options.enabled || process.uptime() < options.threshold) {
       return;
     }
 

--- a/tasks/notify_hooks.js
+++ b/tasks/notify_hooks.js
@@ -16,8 +16,9 @@ module.exports = function gruntTask(grunt) {
     enabled: true,
     max_jshint_notifications: 5,
     title: guessProjectName(),
-	  success: false,
-	  duration: null
+    success: false,
+    duration: null,
+    threshold: 0
   };
 
   var notifyFail = require('../lib/hooks/notify-fail')(grunt, defaults);


### PR DESCRIPTION
Avoid bothering people using fast-acting grunt tasks.
