### PR TITLE
Notify send custom images

### DIFF
--- a/lib/platforms/notify-send.js
+++ b/lib/platforms/notify-send.js
@@ -31,7 +31,7 @@ function notify(options, cb) {
 
   var args = [
     '--hint=int:transient:1',
-    '--icon=' + DEFAULT_IMAGE,
+    '--icon=' + options.image || DEFAULT_IMAGE,
     '--expire-time=' + (options.duration * 1000 || DEFAULT_DURATION),
     options.title,
     options.message

--- a/tasks/notify.js
+++ b/tasks/notify.js
@@ -22,7 +22,7 @@ module.exports = function gruntTask(grunt) {
     var options = this.options(defaults);
     var done = this.async();
 
-    options.image = path.resolve(options.image);
+    options.image = path.resolve(options.image || '');
     if (options.message) {
       notify(options, done);
     } else {

--- a/tasks/notify.js
+++ b/tasks/notify.js
@@ -8,6 +8,7 @@
 'use strict';
 module.exports = function gruntTask(grunt) {
 
+  var path = require('path');
   var notify = require('../lib/notify-lib');
   var guessProjectName = require('../lib/util/guessProjectName');
 
@@ -21,6 +22,7 @@ module.exports = function gruntTask(grunt) {
     var options = this.options(defaults);
     var done = this.async();
 
+    options.image = path.resolve(options.image);
     if (options.message) {
       notify(options, done);
     } else {


### PR DESCRIPTION
This change allows the user to customize the notification image on Linux.

Path resolving is done by node's [path.resolve(to)](https://nodejs.org/docs/latest/api/path.html#path_path_resolve_from_to).
Relative paths are admissible.

Example:

``` javascript
//in node
var path = require('path');
var notify = require('../lib/notify-lib');

notify({
    image: 'my_logo.png',
    duration: 4,
    title: '...',
    message: '...',
});

//in grunt
grunt.initConfig({
    notify: {
        options: {
            duration: 4,
            image: 'my_logo.png',
            title: '...',
            message: '...',
        }
    }
});
```
