### PR TITLE
Fixes problems with growlnotify for windows.

### DIFF
--- a/lib/platforms/growl-notify.js
+++ b/lib/platforms/growl-notify.js
@@ -87,8 +87,7 @@ function createTitleArg(title) {
 
 function createMessageArg(message) {
   return [
-    macOnly('-m'),
-    message
+    macOnly('-m ') + message
   ];
 }
 


### PR DESCRIPTION
If running on windows, you end up with an empty argument which ends up being a set of double quotes and that doesn't compute for growlnotify.