### PR TITLE
Fix windows paths with latest node.js

### DIFF
--- a/lib/platforms/toaster.js
+++ b/lib/platforms/toaster.js
@@ -16,9 +16,9 @@ var semver = require('semver');
 
 // A wee Win8 console notifications app. Post toast notifications from the console, making it easy to integrate into existing batch scripts etc.
 // Toaster by Nels Oscar https://github.com/nels-o/toaster
-var CMD = path.resolve(__dirname + '../../../bin/toaster/toast.exe');
+var CMD = path.join(__dirname, '../../bin/toaster/toast.exe');
 var IS_WINDOWS = os.type() === 'Windows_NT';
-var DEFAULT_IMAGE = path.resolve(__dirname + '../../../images/grunt-logo.png');
+var DEFAULT_IMAGE = path.join(__dirname, '../../images/grunt-logo.png');
 
 
 function supported(options) {

--- a/lib/platforms/toaster.js
+++ b/lib/platforms/toaster.js
@@ -16,9 +16,9 @@ var semver = require('semver');
 
 // A wee Win8 console notifications app. Post toast notifications from the console, making it easy to integrate into existing batch scripts etc.
 // Toaster by Nels Oscar https://github.com/nels-o/toaster
-var CMD = path.join(__dirname, '../../bin/toaster/toast.exe');
+var CMD = path.resolve(__dirname, '../../bin/toaster/toast.exe');
 var IS_WINDOWS = os.type() === 'Windows_NT';
-var DEFAULT_IMAGE = path.join(__dirname, '../../images/grunt-logo.png');
+var DEFAULT_IMAGE = path.resolve(__dirname, '../../images/grunt-logo.png');
 
 
 function supported(options) {


### PR DESCRIPTION
Fixes the paths for Toast and the Grunt image on Windows 10 and the latest node.js version.

Tested on Windows 10 64bit with the latest Node.js (v5.7.0).

#116 